### PR TITLE
Update readme template: change "Reference" to "Guide"

### DIFF
--- a/standards/readme-format.md
+++ b/standards/readme-format.md
@@ -56,7 +56,7 @@ This tool is part of the astrophotography pipeline. For comprehensive documentat
 
 - **[Pipeline Overview](https://github.com/jewzaam/ap-base/blob/main/docs/index.md)** - Full pipeline documentation
 - **[Workflow Guide](https://github.com/jewzaam/ap-base/blob/main/docs/workflow.md)** - Detailed workflow with diagrams
-- **[ap-<name> Reference](https://github.com/jewzaam/ap-base/blob/main/docs/tools/ap-<name>.md)** - API reference for this tool
+- **[ap-<name> Guide](https://github.com/jewzaam/ap-base/blob/main/docs/tools/ap-<name>.md)** - Detailed usage guide for this tool
 ```
 
 Replace `<name>` with the actual project name (e.g., `ap-common`, `ap-cull-lights`).


### PR DESCRIPTION
## Summary
Updated the readme format standard to use more descriptive language for the tool documentation link, changing from "API reference" to "Detailed usage guide".

## Changes
- Updated the documentation link label from "ap-<name> Reference" to "ap-<name> Guide"
- Updated the link description from "API reference for this tool" to "Detailed usage guide for this tool"

## Rationale
This change better reflects the actual content and purpose of the tool documentation. The term "Guide" is more accurate and user-friendly than "Reference", and the updated description better sets expectations for what users will find in the documentation.

https://claude.ai/code/session_01Xzghb7xwZnsd3pPgYtWhf8