### PR TITLE
Update docs and CLI standards based on actual source code

### DIFF
--- a/docs/tools/ap-common.md
+++ b/docs/tools/ap-common.md
@@ -48,6 +48,22 @@ date = normalize_date("2026-01-29T12:30:00")  # "2026-01-29"
 filter_name = normalize_filterName("Luminance")  # "L"
 ```
 
+#### build_normalized_filters() - Build Normalized Filter Criteria
+
+```python
+from ap_common.normalization import build_normalized_filters
+
+# Build normalized filter criteria for matching
+filters = build_normalized_filters({
+    "camera": "ASI294MC",
+    "filter": "Ha",
+    "gain": "100"
+})
+# Returns normalized filters with None values converted to empty strings
+```
+
+Used for strict matching of calibration frames - normalizes None values to empty strings for consistent comparison.
+
 ### filesystem.py - File Operations
 
 ```python

--- a/docs/tools/ap-copy-master-to-blink.md
+++ b/docs/tools/ap-copy-master-to-blink.md
@@ -26,8 +26,10 @@ python -m ap_copy_master_to_blink <library_dir> <blink_dir> [options]
 |----------|-------------|
 | `library_dir` | Path to calibration library (supports env vars like `$VAR`) |
 | `blink_dir` | Path to blink directory tree (supports env vars) |
-| `--dry-run` | Show what would be copied without actually copying files |
+| `--dryrun` | Show what would be copied without actually copying files |
 | `--debug` | Enable debug logging |
+| `--quiet`, `-q` | Suppress progress output |
+| `--allow-bias` | Allow shorter darks with bias frames (default: only exact exposure match darks) |
 
 ### Examples
 
@@ -36,10 +38,16 @@ python -m ap_copy_master_to_blink <library_dir> <blink_dir> [options]
 python -m ap_copy_master_to_blink /calibration/library /data/10_Blink
 
 # With dry-run (show what would be copied without copying)
-python -m ap_copy_master_to_blink /calibration/library /data/10_Blink --dry-run
+python -m ap_copy_master_to_blink /calibration/library /data/10_Blink --dryrun
 
 # With debug output
 python -m ap_copy_master_to_blink /calibration/library /data/10_Blink --debug
+
+# With quiet mode (minimal output)
+python -m ap_copy_master_to_blink /calibration/library /data/10_Blink --quiet
+
+# Allow shorter darks with bias frames
+python -m ap_copy_master_to_blink /calibration/library /data/10_Blink --allow-bias
 ```
 
 ## Workflow Position
@@ -58,9 +66,12 @@ python -m ap_copy_master_to_blink /calibration/library /data/10_Blink --debug
 Priority matching (in order):
 
 1. **Exact exposure match**: Same camera, gain, offset, settemp, readoutmode, and exposure time
-2. **Shorter exposure + bias**: If no exact match, find the longest dark exposure < light exposure
+2. **Shorter exposure + bias** (requires `--allow-bias`): If no exact match, find the longest dark exposure < light exposure
    - **Requires matching bias**: Will not use shorter dark without bias
-3. **No match**: If no exact dark and no bias, skip (logged as missing)
+   - **Default behavior**: Without `--allow-bias`, only exact exposure match darks are copied
+3. **No match**: If no exact dark and no bias (or `--allow-bias` not specified), skip (logged as missing)
+
+**Note**: By default, only exact exposure match darks are copied. Use `--allow-bias` to enable shorter dark + bias frame matching.
 
 ### Flat Frames
 

--- a/docs/tools/ap-create-master.md
+++ b/docs/tools/ap-create-master.md
@@ -21,7 +21,7 @@ pip install git+https://github.com/jewzaam/ap-create-master.git
 ## Usage
 
 ```bash
-python -m ap_master_calibration <input_dir> <output_dir> [options]
+python -m ap_create_master <input_dir> <output_dir> [options]
 ```
 
 ### Options
@@ -34,8 +34,12 @@ python -m ap_master_calibration <input_dir> <output_dir> [options]
 | `--dark-master-dir DIR` | Dark library for flat calibration |
 | `--pixinsight-binary PATH` | Path to PixInsight executable |
 | `--script-only` | Generate scripts without executing |
+| `--script-dir DIR` | Directory for scripts and logs (default: output_dir/logs) |
 | `--instance-id ID` | PixInsight instance ID (default: 123) |
 | `--no-force-exit` | Keep PixInsight open after execution |
+| `--dryrun` | Show what would be done without executing |
+| `--debug` | Enable debug logging |
+| `--quiet`, `-q` | Suppress progress output |
 
 ## Frame Grouping
 
@@ -119,11 +123,11 @@ Masters created in a run are **not used** for flat calibration in that same run.
 
 ```bash
 # Stage 1: Generate bias and dark masters
-python -m ap_master_calibration ./bias_and_darks ./masters \
+python -m ap_create_master ./bias_and_darks ./masters \
     --pixinsight-binary "/path/to/PixInsight"
 
 # Stage 2: Generate flat masters using Stage 1 outputs
-python -m ap_master_calibration ./flats ./output \
+python -m ap_create_master ./flats ./output \
     --bias-master-dir ./masters/master \
     --dark-master-dir ./masters/master \
     --pixinsight-binary "/path/to/PixInsight"
@@ -142,14 +146,14 @@ When matching library masters to flats:
 ### Basic Usage
 
 ```bash
-python -m ap_master_calibration /calibration /output \
+python -m ap_create_master /calibration /output \
     --pixinsight-binary "C:\Program Files\PixInsight\bin\PixInsight.exe"
 ```
 
 ### With Existing Library
 
 ```bash
-python -m ap_master_calibration /flats /output \
+python -m ap_create_master /flats /output \
     --bias-master-dir /library/BIAS \
     --dark-master-dir /library/DARK \
     --pixinsight-binary "/opt/PixInsight/bin/PixInsight"
@@ -158,7 +162,29 @@ python -m ap_master_calibration /flats /output \
 ### Script Only (No Execution)
 
 ```bash
-python -m ap_master_calibration /calibration /output --script-only
+python -m ap_create_master /calibration /output --script-only
+```
+
+### Dry Run
+
+```bash
+# See what would be generated without executing
+python -m ap_create_master /calibration /output --dryrun
+```
+
+### With Debug Output
+
+```bash
+python -m ap_create_master /calibration /output --debug \
+    --pixinsight-binary "C:\Program Files\PixInsight\bin\PixInsight.exe"
+```
+
+### Quiet Mode
+
+```bash
+# Minimal output
+python -m ap_create_master /calibration /output --quiet \
+    --pixinsight-binary "C:\Program Files\PixInsight\bin\PixInsight.exe"
 ```
 
 ## Troubleshooting

--- a/docs/tools/ap-move-light-to-data.md
+++ b/docs/tools/ap-move-light-to-data.md
@@ -27,8 +27,13 @@ python -m ap_move_light_to_data <source_dir> <dest_dir> [options]
 
 ### Options
 
-- `-d, --debug`: Enable debug output
-- `-n, --dry-run`: Show what would be done without actually moving files
+| Option | Description |
+|--------|-------------|
+| `-d`, `--debug` | Enable debug output |
+| `-n`, `--dryrun` | Show what would be done without moving files |
+| `-q`, `--quiet` | Suppress progress output |
+| `--allow-bias` | Allow shorter darks with bias frames (default: only exact exposure match darks) |
+| `--path-pattern REGEX` | Filter light directories by regex pattern (e.g., `"M31"`, `"FILTER_Ha"`) |
 
 ### Examples
 
@@ -42,7 +47,25 @@ python -m ap_move_light_to_data \
 python -m ap_move_light_to_data \
     "/data/astrophotography/RedCat51@f4.9+ASI2600MM/10_Blink" \
     "/data/astrophotography/RedCat51@f4.9+ASI2600MM/20_Data" \
-    --dry-run
+    --dryrun
+
+# Quiet mode (minimal output)
+python -m ap_move_light_to_data \
+    "/data/astrophotography/RedCat51@f4.9+ASI2600MM/10_Blink" \
+    "/data/astrophotography/RedCat51@f4.9+ASI2600MM/20_Data" \
+    --quiet
+
+# Process only specific target (M31)
+python -m ap_move_light_to_data \
+    "/data/astrophotography/RedCat51@f4.9+ASI2600MM/10_Blink" \
+    "/data/astrophotography/RedCat51@f4.9+ASI2600MM/20_Data" \
+    --path-pattern "M31"
+
+# Process only Ha filter
+python -m ap_move_light_to_data \
+    "/data/astrophotography/RedCat51@f4.9+ASI2600MM/10_Blink" \
+    "/data/astrophotography/RedCat51@f4.9+ASI2600MM/20_Data" \
+    --path-pattern "FILTER_Ha"
 ```
 
 ## Calibration Requirements
@@ -66,10 +89,29 @@ Lights are only moved when calibration frames are found (in the lights directory
 
 ### Bias Requirement
 
-Bias frames are **only required** when the dark exposure time does not match the light exposure time. This is because darks with mismatched exposure times need bias subtraction for proper scaling.
+Bias frames are **only required** when the dark exposure time does not match the light exposure time and `--allow-bias` is specified. This is because darks with mismatched exposure times need bias subtraction for proper scaling.
 
-- If dark exposure matches light exposure: **No bias required**
-- If dark exposure differs from light exposure: **Bias required**
+- **Default behavior**: Without `--allow-bias`, only exact exposure match darks are used
+- **With `--allow-bias`**:
+  - If dark exposure matches light exposure: **No bias required**
+  - If dark exposure differs from light exposure: **Bias required**
+
+## Path Pattern Filtering
+
+Use `--path-pattern` to process only specific targets or filters:
+
+```bash
+# Process only M31 target
+python -m ap_move_light_to_data 10_Blink 20_Data --path-pattern "M31"
+
+# Process only Ha filter
+python -m ap_move_light_to_data 10_Blink 20_Data --path-pattern "FILTER_Ha"
+
+# Process multiple patterns (regex OR)
+python -m ap_move_light_to_data 10_Blink 20_Data --path-pattern "M31|M42"
+```
+
+The pattern is matched against the full directory path, allowing flexible filtering by target name, filter, date, or any other path component.
 
 ## Frame Type Support
 

--- a/standards/cli.md
+++ b/standards/cli.md
@@ -69,6 +69,47 @@ Source and destination directories are positional, not options.
 | No period at end | `help="source directory"` |
 | Under 60 characters | Keep it brief |
 
+## Default Values
+
+**Single Source of Truth:** Set default values in ONE place only.
+
+### For CLI Arguments
+
+Set defaults in `argparse` argument definition, **not** in function signatures:
+
+**Good:**
+```python
+# config.py
+DEFAULT_PATH_PATTERN = r".*[/\\]accept[/\\].*"
+
+# CLI
+parser.add_argument(
+    "--path-pattern",
+    default=config.DEFAULT_PATH_PATTERN,
+    help="regex pattern to match paths"
+)
+
+# Function - no default in signature
+def process(path_pattern: str = None):
+    # None means "use whatever caller passed"
+    pass
+```
+
+**Bad:**
+```python
+# CLI
+parser.add_argument("--path-pattern", default=r".*accept.*")
+
+# Function - DUPLICATE default
+def process(path_pattern: str = r".*accept.*"):  # Wrong!
+    pass
+```
+
+**Rationale:**
+- Prevents inconsistencies when defaults change
+- Clear separation: CLI layer sets policy, function layer implements logic
+- Function can be called programmatically with different defaults
+
 ## Exit Codes
 
 Define as module-level constants with `EXIT_` prefix:


### PR DESCRIPTION
- Add build_normalized_filters() documentation to ap-common.md
- Fix module name from ap_master_calibration to ap_create_master throughout
- Fix flag names: --dry-run to --dryrun (matches actual CLI)
- Add missing CLI flags to all tool docs: --quiet, --debug, --dryrun
- Add --allow-bias flag documentation for dark matching behavior
- Add --path-pattern flag documentation for directory filtering
- Add CLI standards section on default value placement

Assisted-by: Claude Code (Claude Sonnet 4.5)