### PR TITLE
Update documentation to use python -m pip install

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,14 +68,14 @@ flowchart TB
 All tools can be installed from git:
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-move-raw-light-to-blink.git
-pip install git+https://github.com/jewzaam/ap-cull-light.git
-pip install git+https://github.com/jewzaam/ap-empty-directory.git
-pip install git+https://github.com/jewzaam/ap-move-light-to-data.git
-pip install git+https://github.com/jewzaam/ap-preserve-header.git
-pip install git+https://github.com/jewzaam/ap-create-master.git
-pip install git+https://github.com/jewzaam/ap-move-master-to-library.git
-pip install git+https://github.com/jewzaam/ap-copy-master-to-blink.git
+python -m pip install git+https://github.com/jewzaam/ap-move-raw-light-to-blink.git
+python -m pip install git+https://github.com/jewzaam/ap-cull-light.git
+python -m pip install git+https://github.com/jewzaam/ap-empty-directory.git
+python -m pip install git+https://github.com/jewzaam/ap-move-light-to-data.git
+python -m pip install git+https://github.com/jewzaam/ap-preserve-header.git
+python -m pip install git+https://github.com/jewzaam/ap-create-master.git
+python -m pip install git+https://github.com/jewzaam/ap-move-master-to-library.git
+python -m pip install git+https://github.com/jewzaam/ap-copy-master-to-blink.git
 ```
 
 The `ap-common` package is installed automatically as a dependency.

--- a/docs/tools/ap-common.md
+++ b/docs/tools/ap-common.md
@@ -15,7 +15,7 @@ Shared utilities package for astrophotography tools.
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-common.git
+python -m pip install git+https://github.com/jewzaam/ap-common.git
 ```
 
 ## Modules

--- a/docs/tools/ap-copy-master-to-blink.md
+++ b/docs/tools/ap-copy-master-to-blink.md
@@ -11,7 +11,7 @@ Copy master calibration frames from library to blink directories where light fra
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-copy-master-to-blink.git
+python -m pip install git+https://github.com/jewzaam/ap-copy-master-to-blink.git
 ```
 
 ## Usage

--- a/docs/tools/ap-create-master.md
+++ b/docs/tools/ap-create-master.md
@@ -9,7 +9,7 @@ Automated generation of master calibration frames using PixInsight.
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-create-master.git
+python -m pip install git+https://github.com/jewzaam/ap-create-master.git
 ```
 
 ## Requirements

--- a/docs/tools/ap-cull-light.md
+++ b/docs/tools/ap-cull-light.md
@@ -9,7 +9,7 @@ Quality control filtering for light frames based on HFR and RMS thresholds.
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-cull-light.git
+python -m pip install git+https://github.com/jewzaam/ap-cull-light.git
 ```
 
 ## Usage

--- a/docs/tools/ap-empty-directory.md
+++ b/docs/tools/ap-empty-directory.md
@@ -21,7 +21,7 @@ This tool is used to clean up intermediate calibration files that are not moved 
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-empty-directory.git
+python -m pip install git+https://github.com/jewzaam/ap-empty-directory.git
 ```
 
 ## Usage

--- a/docs/tools/ap-move-light-to-data.md
+++ b/docs/tools/ap-move-light-to-data.md
@@ -11,7 +11,7 @@ Calibration frames are searched for in the lights directory first, then in paren
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-move-light-to-data.git
+python -m pip install git+https://github.com/jewzaam/ap-move-light-to-data.git
 ```
 
 ## Usage

--- a/docs/tools/ap-move-master-to-library.md
+++ b/docs/tools/ap-move-master-to-library.md
@@ -9,7 +9,7 @@ Organize master calibration frames into a structured library.
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-move-master-to-library.git
+python -m pip install git+https://github.com/jewzaam/ap-move-master-to-library.git
 ```
 
 ## Usage

--- a/docs/tools/ap-move-raw-light-to-blink.md
+++ b/docs/tools/ap-move-raw-light-to-blink.md
@@ -9,7 +9,7 @@ Move and organize light frames from raw capture to organized directory structure
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-move-raw-light-to-blink.git
+python -m pip install git+https://github.com/jewzaam/ap-move-raw-light-to-blink.git
 ```
 
 ## Usage

--- a/docs/tools/ap-preserve-header.md
+++ b/docs/tools/ap-preserve-header.md
@@ -9,7 +9,7 @@ Preserve metadata from file paths into FITS/XISF headers.
 ## Installation
 
 ```bash
-pip install git+https://github.com/jewzaam/ap-preserve-header.git
+python -m pip install git+https://github.com/jewzaam/ap-preserve-header.git
 ```
 
 ## Usage


### PR DESCRIPTION
- Replace all pip install commands with python -m pip install
- Ensures pip uses the correct Python interpreter
- Prevents PATH issues in virtual environments
- Updates 10 documentation files with 17 total command changes

Assisted-by: Claude Code (claude-sonnet-4-5-20250929)