### PR TITLE
Add Typecheck badge and document ap-copy-master-to-blink module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This repository serves as a monorepo aggregating all astrophotography pipeline p
 ```text
 ap-base/
 ├── ap-common/                   # Shared utilities and common code
+├── ap-copy-master-to-blink/     # Master calibration frame distribution
 ├── ap-cull-light/               # Light frame selection/culling
 ├── ap-create-master/            # Master calibration frame creation
 ├── ap-empty-directory/          # Directory cleanup utility

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository serves three primary functions:
 ```text
 ap-base/
 ├── ap-common/                   # Shared utilities and common code
+├── ap-copy-master-to-blink/     # Master calibration frame distribution
 ├── ap-cull-light/               # Light frame selection/culling
 ├── ap-create-master/            # Master calibration frame creation
 ├── ap-empty-directory/          # Directory cleanup utility


### PR DESCRIPTION
## Summary
This PR updates documentation standards and adds a new module to the project structure documentation.

## Key Changes
- Updated README format standards to include a new Typecheck badge as the 7th standard badge (between Lint and Format badges)
- Added `ap-copy-master-to-blink` module documentation to both `README.md` and `CLAUDE.md`, describing it as a "Master calibration frame distribution" utility
- Updated badge count from six to seven in the standards documentation

## Details
The Typecheck badge follows the same pattern as existing workflow badges and points to a new `typecheck.yml` workflow. The new `ap-copy-master-to-blink` module is positioned in the project structure between `ap-common` and `ap-cull-light`, indicating it's part of the core astrophotography pipeline utilities.

https://claude.ai/code/session_01WYjWE68Md31DQxkxup76Hw